### PR TITLE
decode text files

### DIFF
--- a/sphinxtogithub/sphinxtogithub.py
+++ b/sphinxtogithub/sphinxtogithub.py
@@ -34,7 +34,7 @@ class Replacer(object):
 
     def process(self, text):
 
-        return text.replace( self.from_, self.to )
+        return text.decode('ascii', 'ignore').replace( self.from_, self.to )
 
 class FileHandler(object):
     "Applies a series of replacements the contents of a file inplace"


### PR DESCRIPTION
For whatever reason, in our use of sphinx-to-github, the addon throws this error:

```
File "/Users/deus/code/cloudant/api-reference/venv/lib/python2.7/site-packages/sphinxtogithub/sphinxtogithub.py", line 40, in process
return text.replace( self.from_, self.to )
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 2091: ordinal not in range(128)
```

To fix it, I made sure to decode each text file before replacing the directory names in them.

Tests still pass.
